### PR TITLE
Creation of the become-a-host-option

### DIFF
--- a/app/views/concert_halls/_form.html.erb
+++ b/app/views/concert_halls/_form.html.erb
@@ -9,6 +9,11 @@
         </ul>
       </div>
       <% end %>
+    <p>
+    <h5><strong>Gig Berry</strong> connects musicians and concert halls owners. </h5>
+    <h6> The hosts are the <strong>lifeblood of the community</strong> by providing travelers with the unique opportunity to perform. </h6>
+    <h6> <strong>Rent your concert hall</strong> and let the magic happen 🎼 </h6>
+    <p>
     <div class="form-container">
       <%= f.input :name %>
       <% if @concert_hall.new_record? %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -17,6 +17,9 @@
         <li class="nav-item">
           <%= link_to "Reservations",  user_reservations_path(current_user.id), class: "nav-link" %>
         </li>
+        <li class="nav-item">
+          <%= link_to "Become a Host", new_concert_hall_path, class: "nav-link" %>
+        </li>
         <li class="nav-item dropdown">
           <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
           <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">


### PR DESCRIPTION
Hey guys ! 

I have added the option "Become an Host" on the navbar that redirects to the form to create a concert hall.

I have also added a short text before the form (that can be modified ofc), as follows : 

"Gig Berry connects musicians and concert halls owners.
The hosts are the lifeblood of the community by providing travelers with the unique opportunity to perform.
Rent your concert hall and let the magic happen 🎼 "